### PR TITLE
fix: add additional URLs to exclude for multiplayer pages

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -17,6 +17,8 @@ export const DUEL_STARTING_TITLES = [
 const EXCLUDE_URLS = [
   "https://www.geoguessr.com/",
   "https://www.geoguessr.com/party",
+  "https://www.geoguessr.com/multiplayer",
+  "https://www.geoguessr.com/multiplayer/teams",
   "https://www.geoguessr.com/multiplayer/battle-royale-countries",
   "https://www.geoguessr.com/multiplayer/battle-royale-distance",
   "https://www.geoguessr.com/multiplayer/unranked-teams"


### PR DESCRIPTION
- The title of `https://www.geoguessr.com/{lang}/duels/{id}summary` and `https://www.geoguessr.com/duels/{id}/summary` are
 "GeoGuessr - Let's explore the world!" 
- If we back to the duel/team duel page, nofitier will be fired wrongly
 